### PR TITLE
Update structs to Dalamud v14

### DIFF
--- a/TomestoneViewer/GameSystems/TeamList.cs
+++ b/TomestoneViewer/GameSystems/TeamList.cs
@@ -44,11 +44,11 @@ public class TeamList
         }
 
         // Add self if not in party
-        if (this.Members.Count == 0 && Service.ClientState.LocalPlayer != null)
+        if (this.Members.Count == 0 && Service.PlayerState.IsLoaded)
         {
-            var selfName = Service.ClientState.LocalPlayer.Name.TextValue;
-            var selfWorldId = Service.ClientState.LocalPlayer.HomeWorld.RowId;
-            var selfJobId = Service.ClientState.LocalPlayer.ClassJob.RowId;
+            var selfName = Service.PlayerState.CharacterName;
+            var selfWorldId = Service.PlayerState.HomeWorld.RowId;
+            var selfJobId = Service.PlayerState.ClassJob.RowId;
             this.AddTeamMember(selfName, (ushort)selfWorldId, selfJobId, true, false);
         }
     }

--- a/TomestoneViewer/Service.cs
+++ b/TomestoneViewer/Service.cs
@@ -45,6 +45,8 @@ internal class Service
 
     [PluginService] internal static IDataManager DataManager { get; private set; } = null!;
 
+    [PluginService] internal static IPlayerState PlayerState { get; private set; } = null!;
+
     [PluginService] internal static IFlyTextGui FlyTextGui { get; private set; } = null!;
 
     [PluginService] internal static ISigScanner SigScanner { get; private set; } = null!;

--- a/TomestoneViewer/TomestoneViewer.csproj
+++ b/TomestoneViewer/TomestoneViewer.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.SDK/13.0.0">
+<Project Sdk="Dalamud.NET.SDK/14.0.0">
 
   <PropertyGroup>
     <Authors>Anomek</Authors>

--- a/TomestoneViewer/packages.lock.json
+++ b/TomestoneViewer/packages.lock.json
@@ -4,15 +4,15 @@
     "net9.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[13.0.0, )",
-        "resolved": "13.0.0",
-        "contentHash": "Mb3cUDSK/vDPQ8gQIeuCw03EMYrej1B4J44a1AvIJ9C759p9XeqdU9Hg4WgOmlnlPe0G7ILTD32PKSUpkQNa8w=="
+        "requested": "[14.0.0, )",
+        "resolved": "14.0.0",
+        "contentHash": "9c1q/eAeAs82mkQWBOaCvbt3GIQxAIadz5b/7pCXDIy9nHPtnRc+tDXEvKR+M36Wvi7n+qBTevRupkLUQp6DFA=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[1.2.25, )",
-        "resolved": "1.2.25",
-        "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
+        "requested": "[1.2.39, )",
+        "resolved": "1.2.39",
+        "contentHash": "fcFN01tDTIQqDuTwr1jUQK/geofiwjG5DycJQOnC72i1SsLAk1ELe+apBOuZ11UMQG8YKFZG1FgvjZPbqHyatg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
Updates Service interfaces: [IClientState](https://dalamud.dev/api/Dalamud.Plugin.Services/Interfaces/IClientState/) references to point to the [new v14](https://dalamud.dev/versions/v14/#new-service-iplayerstate) [IPlayerState interface](https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Plugin/Services/IPlayerState.cs) as `IClientState.LocalPlayer` has been [deprecated in v14](https://dalamud.dev/versions/v14/#iclientstate).